### PR TITLE
feat: add support for custom decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ class MyTestSuite {
 Custom decorators can be created using `createTestDecorator` and `createSuiteDecorator` functions 
 
 #### Test decorator
-The createTestDecorator function enables the generation of custom test decorators.
+The `createTestDecorator` function enables the generation of custom test decorators.
 Attempting to utilize a custom test decorator on a method that lacks the `@test` decoration will result in an error.
 
 ```ts
@@ -357,7 +357,7 @@ class MyTestSuite {
 ```
 
 #### Suite decorator
-The createSuiteDecorator function allows the creation of custom suite decorators.
+The `createSuiteDecorator` function allows the creation of custom suite decorators.
 Attempting to apply a custom suite decorator to a class that lacks the `@suite` decoration will result in an error.
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -322,11 +322,11 @@ class MyTestSuite {
 
 
 ### Custom decorators
-For more advanced use cases, you can create your own decorators using `createTestDecorator` and `createSuiteDecorator` functions.
+Custom decorators can be created using `createTestDecorator` and `createSuiteDecorator` functions 
 
 #### Test decorator
 The createTestDecorator function enables the generation of custom test decorators.
-Attempting to utilize a custom test decorator on a method that lacks the @test decoration will result in an error.
+Attempting to utilize a custom test decorator on a method that lacks the `@test` decoration will result in an error.
 
 ```ts
 import { suite, createTestDecorator } from 'playwright-decorators';
@@ -358,7 +358,7 @@ class MyTestSuite {
 
 #### Suite decorator
 The createSuiteDecorator function allows the creation of custom suite decorators.
-Attempting to apply a custom suite decorator to a class that lacks the @suite decoration will result in an error.
+Attempting to apply a custom suite decorator to a class that lacks the `@suite` decoration will result in an error.
 
 ```ts
 import { suite, createSuiteDecorator } from 'playwright-decorators';

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ class MyTestSuite {
   }
 }
 ```
+For more advanced use cases, please see [custom decorators](#custom-decorators) section.
 
 ## 📝 Documentation
 ### Creating a test suite: `@suite(options?)`
@@ -317,3 +318,61 @@ class MyTestSuite {
 #### Options
 - `type` (required) - type of annotation, for example 'skip' or 'fail'.
 - `description` (optional) - description of annotation.
+
+
+
+### Custom decorators
+For more advanced use cases, you can create your own decorators using `createTestDecorator` and `createSuiteDecorator` functions.
+
+#### Test decorator
+The createTestDecorator function enables the generation of custom test decorators.
+Attempting to utilize a custom test decorator on a method that lacks the @test decoration will result in an error.
+
+```ts
+import { suite, createTestDecorator } from 'playwright-decorators';
+import playwright from '@playwright/test';
+
+const customTestDecorator = createTestDecorator('customTestDecorator', ({test, context}) => {
+  // create code using hooks provided by test decorator...
+  test.beforeTest(() => { /* ... */ })
+  test.afterTest(() => { /* ... */ })
+
+  // ...or Playwright hooks
+  playwright.beforeEach(() => {
+    // ...
+  })
+});
+```
+
+Then use it on `@test` decorator:
+```ts
+@suite()
+class MyTestSuite {
+  @customTestDecorator() // <-- Decorate test with custom decorator
+  @test()
+  async myTest({ page }) {
+    // ...
+  }
+}
+```
+
+#### Suite decorator
+The createSuiteDecorator function allows the creation of custom suite decorators.
+Attempting to apply a custom suite decorator to a class that lacks the @suite decoration will result in an error.
+
+```ts
+import { suite, createSuiteDecorator } from 'playwright-decorators';
+
+const customSuiteDecorator = createSuiteDecorator('customSuiteDecorator', ({suite, context}) => {
+  // ...
+});
+```
+
+Then use it on `@suite` decorator:
+```ts
+@customSuiteDecorator() // <-- Decorate suite with custom decorator
+@suite()
+class MyTestSuite {
+  // ...
+}
+```

--- a/lib/custom.ts
+++ b/lib/custom.ts
@@ -1,0 +1,47 @@
+import {isSuiteDecoratedMethod, SuiteDecorator} from "./suite.decorator";
+import {isTestDecoratedMethod, TestDecorator} from "./test.decorator";
+import {NotSuiteDecoratedMethodError, NotTestDecoratedMethodError} from "./errors";
+
+type CustomSuiteDecorator = (params: { suite: SuiteDecorator, context?: ClassMethodDecoratorContext }) => void;
+
+/**
+ * Generates a decorator specifically intended for use with the @suite.
+ * Applying this decorator in other contexts will result in an error.
+ * @param name name of the decorator
+ * @param suiteDecorator a custom decorator function
+ */
+export const createSuiteDecorator = (name: string, suiteDecorator: CustomSuiteDecorator) => {
+  return function(originalMethod: any, context?: any) {
+    if (!isSuiteDecoratedMethod(originalMethod)) {
+      throw new NotSuiteDecoratedMethodError(name, originalMethod);
+    }
+    
+    originalMethod.suiteDecorator.initialized(() => {
+      suiteDecorator({
+        suite: originalMethod.suiteDecorator,
+        context
+      });
+    })
+  }
+}
+
+type CustomTestDecorator = (params: { test: TestDecorator, context?: any }) => void;
+
+/**
+ * Generates a decorator specifically intended for use with the @test.
+ * Applying this decorator in other contexts will result in an error.
+ * @param name name of the decorator
+ * @param testDecorator a custom decorator function
+ */
+export const createTestDecorator = (name: string, testDecorator: CustomTestDecorator) => {
+  return function(originalMethod: any, context?: any) {
+    if (!isTestDecoratedMethod(originalMethod)) {
+      throw new NotTestDecoratedMethodError(name, originalMethod);
+    }
+
+    testDecorator({
+      test: originalMethod.testDecorator,
+      context
+    })
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -29,3 +29,9 @@ export {
   NotSuiteDecoratedMethodError,
   NotTestDecoratedMethodError
 } from './errors';
+
+// custom
+export {
+  createSuiteDecorator,
+  createTestDecorator
+} from './custom';

--- a/lib/suite.decorator.ts
+++ b/lib/suite.decorator.ts
@@ -1,7 +1,7 @@
 import playwright from '@playwright/test';
 
 type Constructor = { new (...args: any[]): any };
-type Hook = () => void;
+type SuiteHook = () => void;
 
 interface SuiteDecoratorOptions {
   /**
@@ -43,7 +43,7 @@ export class SuiteDecorator implements SuiteDecoratorOptions {
   fixme: string | boolean = false;
   only = false;
 
-  private initializedHooks: Hook[] = [];
+  private initializedHooks: SuiteHook[] = [];
 
   constructor(private suiteClass: Constructor, options: SuiteDecoratorOptions) {
     this.name = suiteClass.name;
@@ -127,7 +127,7 @@ export class SuiteDecorator implements SuiteDecoratorOptions {
   /**
    * Declares an `initialized` hook that is executed after suite is initialized.
    */
-  initialized(hookFn: Hook) {
+  initialized(hookFn: SuiteHook) {
     this.initializedHooks.push(hookFn);
   }
 }

--- a/lib/test.decorator.ts
+++ b/lib/test.decorator.ts
@@ -1,7 +1,7 @@
 import playwright from '@playwright/test';
 import {decoratePlaywrightTest, TestDecoratorFunction} from "./helpers";
 
-type Hook = () => void | Promise<void>;
+type TestHook = () => void | Promise<void>;
 
 interface TestDecoratorOptions {
   /**
@@ -49,8 +49,8 @@ export class TestDecorator implements TestDecoratorOptions {
   only = false;
   annotations: {type: string, description?: string}[] = [];
 
-  private beforeTestHooks: Hook[] = [];
-  private afterTestHooks: Hook[] = [];
+  private beforeTestHooks: TestHook[] = [];
+  private afterTestHooks: TestHook[] = [];
 
   constructor(private testMethod: any, options: TestDecoratorOptions) {
     this.name = testMethod.name;
@@ -151,14 +151,14 @@ export class TestDecorator implements TestDecoratorOptions {
   /**
    * Declares an `before` hook that is executed before test.
    */
-  beforeTest(initializer: Hook) {
+  beforeTest(initializer: TestHook) {
     this.beforeTestHooks.push(initializer);
   }
   
   /**
    * Declares an `after` hook that is executed after test.
    */
-  afterTest(initializer: Hook) {
+  afterTest(initializer: TestHook) {
     this.afterTestHooks.push(initializer);
   }
 }

--- a/tests/custom.spec.ts
+++ b/tests/custom.spec.ts
@@ -1,0 +1,107 @@
+import playwright, {expect} from "@playwright/test";
+import {
+  suite,
+  test,
+  createSuiteDecorator,
+  createTestDecorator, NotTestDecoratedMethodError, NotSuiteDecoratedMethodError
+} from '../lib';
+
+playwright.describe('custom decorators', () => {
+  playwright.describe('createSuiteDecorator', () => {
+    const called: string[] = [];
+
+    const customSuiteDecorator = createSuiteDecorator('customSuiteDecorator', () => {
+      called.push('customSuiteDecorator');
+    });
+
+    @customSuiteDecorator
+    @suite()
+    class CustomSuiteDecoratorSuite {
+      @test()
+      customTest() {
+        called.push('test#1');
+      }
+      
+      @test()
+      customTest2() {
+        called.push('test#2');
+      }
+    }
+
+    @suite()
+    class SuiteWithoutCustomSuiteDecorator {
+      @test()
+      customTest() {
+        called.push('test#2');
+      }
+    }
+
+    playwright('Should customSuiteDecorator be called before all tests', () => {
+      expect(called.join('->')).toContain('customSuiteDecorator->test#1->test#2');
+    });
+
+    playwright('Should customSuiteDecorator not be called on non decorated suite', () => {
+      expect(called.join('->')).not.toContain('customSuiteDecorator->test#2');
+    });
+
+    playwright('Should call customSuiteDecorator once', () => {
+      const customSuiteDecoratorsCalls = called.filter((item) => item === 'customSuiteDecorator');
+      expect(customSuiteDecoratorsCalls.length).toEqual(1);
+    });
+
+    playwright('Should throw error if decorator is not used on @suite', () => {
+      expect(() => {
+        @customSuiteDecorator
+        class ExampleClass {}
+      }).toThrowError(NotSuiteDecoratedMethodError)
+    });
+  })
+  
+  playwright.describe('createTestDecorator', () => {
+    const called: string[] = [];
+
+    const customTestDecorator = createTestDecorator('customTestDecorator', ({ test }) => {
+      test.beforeTest(() => { called.push('beforeTestHook') });
+      test.afterTest(() => { called.push('afterTestHook') });
+    });
+    
+    @suite()
+    class CustomTestDecoratorSuite {
+      @customTestDecorator
+      @test()
+      testWithCustomTestDecorator() {
+        called.push('testWithCustomTestDecorator');
+      }
+      
+      @test()
+      testWithoutCustomTestDecorator() {
+        called.push('testWithoutCustomTestDecorator');
+      }
+    }
+    
+    playwright('Should `beforeTestHook` be called before test code', () => {
+      expect(called.join('->')).toContain('beforeTestHook->testWithCustomTestDecorator');
+    });
+    
+    playwright('Should `afterTestHook` be called after test code', () => {
+      expect(called.join('->')).toContain('testWithCustomTestDecorator->afterTestHook');
+    });
+    
+    playwright('Should `beforeTestHook` & `afterTestHook` be called once', () => {
+      expect(called.filter((item) => item === 'beforeTestHook').length).toEqual(1);
+      expect(called.filter((item) => item === 'afterTestHook').length).toEqual(1);
+    });
+
+    playwright('Should `beforeTestHook` & `afterTestHook` not be called on non decorated test', () => {
+      expect(called.join('->')).not.toContain('beforeTestHook->testWithoutCustomTestDecorator');
+      expect(called.join('->')).not.toContain('testWithoutCustomTestDecorator->afterTestHook');
+    })
+
+    playwright('Should throw error if decorator is not used on @test', () => {
+      expect(() => {
+        @customTestDecorator
+        class ExampleClass {}
+      }).toThrowError(NotTestDecoratedMethodError)
+    });
+  })
+});

--- a/tests/only.spec.ts
+++ b/tests/only.spec.ts
@@ -54,11 +54,11 @@ playwright.describe('@only decorator', () => {
     // Unfortunately, we cannot call real `playwright.only()` because other tests will not be run, so call needs to be mocked.
     // As the result, we can only check if mocked `playwright.only` was called.
     playwright('@only decorator should run `playwright.only()` before each decorated test', () => {
-      expect(called).toEqual(['playwright.only()', 'focusedTest', 'playwright.only()', 'focusedTest2', 'test']); // playwright.only() is called before @only tests: focusedTest & focusedTest2, but not before test
+      expect(called).toEqual(['playwright.only()', 'playwright.only()', 'focusedTest', 'focusedTest2', 'test']); // playwright.only() is called before @only tests: focusedTest & focusedTest2, but not before test
       cleanup();
     });
   });
-  
+
   playwright.describe('without @suite', () => {
     playwright('should throw NotSuiteOrTestDecoratedMethodError',  () => {
       try {


### PR DESCRIPTION
### Custom decorators
Custom decorators can be created using `createTestDecorator` and `createSuiteDecorator` functions 

#### Test decorator
The `createTestDecorator` function enables the generation of custom test decorators.
Attempting to utilize a custom test decorator on a method that lacks the `@test` decoration will result in an error.

```ts
import { suite, createTestDecorator } from 'playwright-decorators';
import playwright from '@playwright/test';

const customTestDecorator = createTestDecorator('customTestDecorator', ({test, context}) => {
  // create code using hooks provided by test decorator...
  test.beforeTest(() => { /* ... */ })
  test.afterTest(() => { /* ... */ })

  // ...or Playwright hooks
  playwright.beforeEach(() => {
    // ...
  })
});
```

Then use it on `@test` decorator:
```ts
@suite()
class MyTestSuite {
  @customTestDecorator() // <-- Decorate test with custom decorator
  @test()
  async myTest({ page }) {
    // ...
  }
}
```

#### Suite decorator
The `createSuiteDecorator` function allows the creation of custom suite decorators.
Attempting to apply a custom suite decorator to a class that lacks the `@suite` decoration will result in an error.

```ts
import { suite, createSuiteDecorator } from 'playwright-decorators';

const customSuiteDecorator = createSuiteDecorator('customSuiteDecorator', ({suite, context}) => {
  // ...
});
```

Then use it on `@suite` decorator:
```ts
@customSuiteDecorator() // <-- Decorate suite with custom decorator
@suite()
class MyTestSuite {
  // ...
}
```