### PR TITLE
ci: define build, formatting, tests, examples as separate GH checks

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,16 @@
+name: Prepare
+description: Setup environment
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,10 +3,6 @@ description: Setup environment
 runs:
   using: 'composite'
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Setup NodeJS
       uses: actions/setup-node@v3
       with:
@@ -14,3 +10,4 @@ runs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
+      shell: bash

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,30 +16,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup NodeJS
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Lint
-        run: npm run lint
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Build
         run: npm run build
-      - name: Test (library)
+      - name: Test
         run: |
           npx playwright install chromium
-          npm t
-      - name: Test (examples)
-        run: |
-          cd examples
-          npx playwright install chromium
-          npm run build
-          npm t
-      - name: Publish or release proposal
+          npm run test
+      - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
           publish: npm run release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,30 +8,50 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: with NodeJS
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
-      - name: Lint
-        run: npm run lint
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Build
         run: npm run build
-      - name: Test (library)
+
+  code_formatting:
+    name: Code formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Lint
+        run: npm run lint
+      - name: Prettier
+        run: npm run format
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Build
         run: |
           npx playwright install chromium
-          npm t
-      - name: Test (examples)
+          npm run test
+
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Build
+        run: cd examples && npm run build
+      - name: Lint
+        run: cd examples && npm run lint
+      - name: Prettier
+        run: cd examples && npm run prettier
+      - name: Test
         run: |
           cd examples
           npx playwright install chromium
-          npm run build
-          npm t
+          npm run test  

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Prettier
-        run: npm run format
+        run: npm run prettier
 
   test:
     name: Tests
@@ -52,6 +52,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
+      - name: Build lib
+        run: npm run build
       - name: Build
         run: cd examples && npm run build
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
@@ -20,6 +22,8 @@ jobs:
     name: Code formatting
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -31,6 +35,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build
@@ -42,6 +48,8 @@ jobs:
     name: Examples
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -7,11 +7,11 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-var-requires': 'off'
   },
-  "overrides": [
+  overrides: [
     {
-      "files": ["tests/*.ts"],
-      "rules": {
-        "@typescript-eslint/no-unused-vars": "off"
+      files: ['tests/*.ts'],
+      rules: {
+        '@typescript-eslint/no-unused-vars': 'off'
       }
     }
   ]

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,7 @@
     "start": "node app/app.js",
     "build": "tsc",
     "lint": "eslint --ignore-path .gitignore ./app ./tests",
-    "format": "prettier --ignore-path .gitignore --check .",
+    "prettier": "prettier --ignore-path .gitignore --check .",
     "test": "playwright test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "tsc && vite build",
     "postbuild": "dts-bundle-generator --config ./dts-bundle-generator.config.ts",
     "lint": "eslint --ignore-path .gitignore ./lib ./tests",
-    "format": "prettier --ignore-path .gitignore --check ./lib ./tests",
+    "prettier": "prettier --ignore-path .gitignore --check ./lib ./tests",
     "test": "playwright test",
     "changeset": "changeset",
     "version": "changeset version",


### PR DESCRIPTION
- Run prettier during CI workflow
- Present `build`, `code formatting`, `tests` and `examples` as separate Github checks