### PR TITLE
feat: support fixtures

### DIFF
--- a/.changeset/slimy-spiders-cover.md
+++ b/.changeset/slimy-spiders-cover.md
@@ -1,0 +1,53 @@
+---
+"playwright-decorators": minor
+---
+
+Add support for fixtures
+
+This release introduce a new method `extend<T>(customFixture)` that allows to create decorators (`afterAll`, `afterEach`, `test`, `beforeAll`, `beforeEach`) with access to custom fixtures.
+
+```ts
+import { test as base } from 'playwright';
+import { suite, test, extend } from 'playwright-decorators';
+
+// #1 Create fixture type
+type UserFixture = {
+    user: {
+      firstName: string;
+      lastName: string;
+    }
+}
+
+// #2 Create user fixture
+const withUser = base.extend<UserFixture>({
+    user: async ({}, use) => {
+        await use({
+            firstName: 'John',
+            lastName: 'Doe'
+        })
+    }
+})
+
+// #3 Generate afterAll, afterEach, test, beforeAll, beforeEach decorators with access to the user fixture
+const {
+    afterAll,
+    afterEach,
+    test,
+    beforeAll,
+    beforeEach,
+} = extend<UserFixture>(withUser);
+
+// #4 Use decorators
+@suite()
+class MyTestSuite {
+    @beforeAll()
+    async beforeAll({ user }: TestArgs<UserFixture>) { // have access to user fixture
+        // ...
+    }
+
+    @test()
+    async test({ user }: TestArgs<UserFixture>) { // have access to user fixture
+        // ...
+    }
+}
+```

--- a/lib/afterAll.decorator.ts
+++ b/lib/afterAll.decorator.ts
@@ -14,7 +14,7 @@ export interface AfterAllDecoratorOptions<T> {
  * Run method after all tests in the suite.
  * Target class should be marked by @suite decorator.
  */
-export const afterAll = <T = unknown>(options?: AfterAllDecoratorOptions<T>) =>
+export const afterAll = <T = void>(options?: AfterAllDecoratorOptions<T>) =>
   function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
       const decoratedBeforeAll = decoratePlaywrightTest<T>(

--- a/lib/afterAll.decorator.ts
+++ b/lib/afterAll.decorator.ts
@@ -1,21 +1,31 @@
 import playwright from '@playwright/test'
 import { decoratePlaywrightTest } from './helpers'
-import { TestMethod } from './common'
+import { TestMethod, TestType } from './common'
+
+export interface AfterAllDecoratorOptions<T> {
+  /**
+   * Custom playwright instance to use instead of standard one.
+   * For example, provide result of `playwright.extend<T>(customFixture)` to ensure availability of custom fixture in the `afterAll` hook.
+   */
+  playwright?: TestType<T>
+}
 
 /**
  * Run method after all tests in the suite.
  * Target class should be marked by @suite decorator.
  */
-export const afterAll = () =>
-  function (originalMethod: TestMethod, context: ClassMethodDecoratorContext) {
+export const afterAll = <T = unknown>(options?: AfterAllDecoratorOptions<T>) =>
+  function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
-      const decoratedBeforeAll = decoratePlaywrightTest(
+      const decoratedBeforeAll = decoratePlaywrightTest<T>(
         originalMethod,
         (originalMethod) =>
           (...args) =>
             originalMethod.call(this, ...args)
       )
 
-      playwright.afterAll(decoratedBeforeAll)
+      const { afterAll } = options?.playwright || (playwright as TestType<T>)
+
+      afterAll(decoratedBeforeAll)
     })
   }

--- a/lib/afterEach.decorator.ts
+++ b/lib/afterEach.decorator.ts
@@ -14,7 +14,7 @@ export interface AfterEachDecoratorOptions<T> {
  * Run method after each test in suite.
  * Target class should be marked by @suite decorator.
  */
-export const afterEach = <T = unknown>(options?: AfterEachDecoratorOptions<T>) =>
+export const afterEach = <T = void>(options?: AfterEachDecoratorOptions<T>) =>
   function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
       const decoratedBeforeEach = decoratePlaywrightTest<T>(

--- a/lib/afterEach.decorator.ts
+++ b/lib/afterEach.decorator.ts
@@ -1,21 +1,31 @@
 import playwright from '@playwright/test'
 import { decoratePlaywrightTest } from './helpers'
-import { TestMethod } from './common'
+import { TestMethod, TestType } from './common'
+
+export interface AfterEachDecoratorOptions<T> {
+  /**
+   * Custom playwright instance to use instead of standard one.
+   * For example, provide result of `playwright.extend<T>(customFixture)` to ensure availability of custom fixture in the `afterEach` hook.
+   */
+  playwright?: TestType<T>
+}
 
 /**
  * Run method after each test in suite.
  * Target class should be marked by @suite decorator.
  */
-export const afterEach = () =>
-  function (originalMethod: TestMethod, context: ClassMethodDecoratorContext) {
+export const afterEach = <T = unknown>(options?: AfterEachDecoratorOptions<T>) =>
+  function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
-      const decoratedBeforeEach = decoratePlaywrightTest(
+      const decoratedBeforeEach = decoratePlaywrightTest<T>(
         originalMethod,
         (originalMethod) =>
           (...args) =>
             originalMethod.call(this, ...args)
       )
 
-      playwright.afterEach(decoratedBeforeEach)
+      const { afterEach } = options?.playwright || (playwright as TestType<T>)
+
+      afterEach(decoratedBeforeEach)
     })
   }

--- a/lib/beforeAll.decorator.ts
+++ b/lib/beforeAll.decorator.ts
@@ -14,7 +14,7 @@ export interface BeforeAllDecoratorOptions<T> {
  * Run method before all tests in the suite.
  * Target class should be marked by @suite decorator.
  */
-export const beforeAll = <T = unknown>(options?: BeforeAllDecoratorOptions<T>) =>
+export const beforeAll = <T = void>(options?: BeforeAllDecoratorOptions<T>) =>
   function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
       const decoratedBeforeAll = decoratePlaywrightTest<T>(

--- a/lib/beforeEach.decorator.ts
+++ b/lib/beforeEach.decorator.ts
@@ -14,7 +14,7 @@ export interface BeforeEachDecoratorOptions<T> {
  * Run method before each test in the suite.
  * Target class should be marked by @suite decorator.
  */
-export const beforeEach = <T = unknown>(options?: BeforeEachDecoratorOptions<T>) =>
+export const beforeEach = <T = void>(options?: BeforeEachDecoratorOptions<T>) =>
   function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
       const decoratedBeforeEach = decoratePlaywrightTest<T>(

--- a/lib/beforeEach.decorator.ts
+++ b/lib/beforeEach.decorator.ts
@@ -1,21 +1,31 @@
 import playwright from '@playwright/test'
 import { decoratePlaywrightTest } from './helpers'
-import { TestMethod } from './common'
+import { TestMethod, TestType } from './common'
+
+export interface BeforeEachDecoratorOptions<T> {
+  /**
+   * Custom playwright instance to use instead of standard one.
+   * For example, provide result of `playwright.extend<T>(customFixture)` to ensure availability of custom fixture in the `beforeEach` hook.
+   */
+  playwright?: TestType<T>
+}
 
 /**
  * Run method before each test in the suite.
  * Target class should be marked by @suite decorator.
  */
-export const beforeEach = () =>
-  function (originalMethod: TestMethod, context: ClassMethodDecoratorContext) {
+export const beforeEach = <T = unknown>(options?: BeforeEachDecoratorOptions<T>) =>
+  function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     context.addInitializer(function () {
-      const decoratedBeforeEach = decoratePlaywrightTest(
+      const decoratedBeforeEach = decoratePlaywrightTest<T>(
         originalMethod,
         (originalMethod) =>
           (...args) =>
             originalMethod.call(this, ...args)
       )
 
-      playwright.beforeEach(decoratedBeforeEach)
+      const { beforeEach } = options?.playwright || (playwright as TestType<T>)
+
+      beforeEach(decoratedBeforeEach)
     })
   }

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -8,15 +8,15 @@ import {
 } from '@playwright/test'
 
 export type TestInfo = PlaywrightTestInfo
-export type TestArgs<T = unknown> = T &
+export type TestArgs<T = void> = T &
   PlaywrightTestArgs &
   PlaywrightTestOptions &
   PlaywrightWorkerArgs &
   PlaywrightWorkerOptions
-export type TestMethod<T = any> = (args: TestArgs<T>, testInfo: TestInfo) => void | Promise<void>
+export type TestMethod<T = void> = (args: TestArgs<T>, testInfo: TestInfo) => void | Promise<void>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TestClass = { new (...args: any[]): any }
 export type TestType<T = any> = PlaywrightTestType<
-  TestArgs & T,
+  TestArgs<T>,
   PlaywrightWorkerArgs & PlaywrightWorkerOptions
 >

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -3,14 +3,20 @@ import {
   PlaywrightTestOptions,
   PlaywrightWorkerArgs,
   PlaywrightWorkerOptions,
-  TestInfo as PlaywrightTestInfo
+  TestInfo as PlaywrightTestInfo,
+  TestType as PlaywrightTestType
 } from '@playwright/test'
 
 export type TestInfo = PlaywrightTestInfo
-export type TestArgs = PlaywrightTestArgs &
+export type TestArgs<T = unknown> = T &
+  PlaywrightTestArgs &
   PlaywrightTestOptions &
   PlaywrightWorkerArgs &
   PlaywrightWorkerOptions
-export type TestMethod = (args: TestArgs, testInfo: TestInfo) => void | Promise<void>
+export type TestMethod<T = any> = (args: TestArgs<T>, testInfo: TestInfo) => void | Promise<void>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TestClass = { new (...args: any[]): any }
+export type TestType<T = any> = PlaywrightTestType<
+  TestArgs & T,
+  PlaywrightWorkerArgs & PlaywrightWorkerOptions
+>

--- a/lib/extend.ts
+++ b/lib/extend.ts
@@ -1,0 +1,25 @@
+import { afterAll } from './afterAll.decorator'
+import { afterEach } from './afterEach.decorator'
+import { beforeAll } from './beforeAll.decorator'
+import { beforeEach } from './beforeEach.decorator'
+import { test } from './test.decorator'
+import { TestType } from './common'
+
+/**
+ * Generates afterAll, afterEach, test, beforeAll, beforeEach decorators with access to custom fixture.
+ * @param customPlaywright - method returned from playwright.extend<T>
+ */
+export const extend = <T>(customPlaywright: TestType<T>) => {
+  return {
+    afterAll: (...options: Parameters<typeof afterAll>) =>
+      afterAll<T>({ ...options, playwright: customPlaywright }),
+    afterEach: (...options: Parameters<typeof afterEach>) =>
+      afterEach<T>({ ...options, playwright: customPlaywright }),
+    test: (...options: Parameters<typeof test>) =>
+      test<T>({ ...options, playwright: customPlaywright }),
+    beforeAll: (...options: Parameters<typeof beforeAll>) =>
+      beforeAll<T>({ ...options, playwright: customPlaywright }),
+    beforeEach: (...options: Parameters<typeof beforeEach>) =>
+      beforeEach<T>({ ...options, playwright: customPlaywright })
+  }
+}

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,13 +1,13 @@
 import { TestMethod } from './common'
 
-export type TestDecoratorFunction = (testFunction: TestMethod) => TestMethod
+export type TestDecoratorFunction = <T>(testFunction: TestMethod<T>) => TestMethod<T>
 
 /**
  * Wrap a playwright test function with class method, and make it visible externally as original one (function description).
  * It is required, as @playwright/test function do not accept rest parameters.
  */
-export const decoratePlaywrightTest = (
-  testFunction: TestMethod,
+export const decoratePlaywrightTest = <T>(
+  testFunction: TestMethod<T>,
   decorationFunction: TestDecoratorFunction
 ) => {
   const decoratedTestFunction = decorationFunction(testFunction)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,6 +27,7 @@ export { preview } from './preview.decorator'
 
 // common
 export { type TestInfo, type TestArgs } from './common'
+export { extend } from './extend'
 
 // custom
 export { createSuiteDecorator, createTestDecorator, createSuiteAndTestDecorator } from './custom'

--- a/lib/test.decorator.ts
+++ b/lib/test.decorator.ts
@@ -96,9 +96,7 @@ export function isTestDecoratedMethod(method: any): method is TestDecoratedMetho
  *
  * Behaviour of decorator can be modified by other decorators using injected `testDecorator` property.
  */
-export const test = <T = unknown>(
-  options: TestDecoratorOptions = {} // @todo inject playwright
-) =>
+export const test = <T = void>(options: TestDecoratorOptions = {}) =>
   function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     const testDecorator = new TestDecorator(originalMethod, options)
 

--- a/lib/test.decorator.ts
+++ b/lib/test.decorator.ts
@@ -1,10 +1,10 @@
 import playwright from '@playwright/test'
 import { decoratePlaywrightTest, TestDecoratorFunction } from './helpers'
-import { TestMethod } from './common'
+import { TestMethod, TestType } from './common'
 
 type TestHook = () => void | Promise<void>
 
-interface TestDecoratorOptions {
+export interface TestDecoratorOptions {
   /**
    * Name of the test. Default: name of the method
    */
@@ -14,11 +14,17 @@ interface TestDecoratorOptions {
    * If there are some focused @test(s) or @suite(s), all of them will be run but nothing else.
    */
   only?: boolean
+  /**
+   * Custom playwright instance to use instead of standard one.
+   * For example, provide result of `playwright.extend<T>(customFixture)` to ensure availability of custom fixture in the `test` method.
+   */
+  playwright?: TestType
 }
 
 export class TestDecorator implements TestDecoratorOptions {
   name: string
   only = false
+  playwright = playwright
 
   private beforeTestHooks: TestHook[] = []
   private afterTestHooks: TestHook[] = []
@@ -55,7 +61,7 @@ export class TestDecorator implements TestDecoratorOptions {
         await this.handleAfterTestHooks()
       }
 
-    const testRunner = this.only ? playwright.only : playwright
+    const testRunner = this.only ? this.playwright.only : this.playwright
 
     testRunner(this.name, decoratePlaywrightTest(this.testMethod, extendedTestMethod))
   }
@@ -90,8 +96,10 @@ export function isTestDecoratedMethod(method: any): method is TestDecoratedMetho
  *
  * Behaviour of decorator can be modified by other decorators using injected `testDecorator` property.
  */
-export const test = (options: TestDecoratorOptions = {}) =>
-  function (originalMethod: TestMethod, context: ClassMethodDecoratorContext) {
+export const test = <T = unknown>(
+  options: TestDecoratorOptions = {} // @todo inject playwright
+) =>
+  function (originalMethod: TestMethod<T>, context: ClassMethodDecoratorContext) {
     const testDecorator = new TestDecorator(originalMethod, options)
 
     Object.assign(originalMethod, { testDecorator })

--- a/tests/extend.spec.ts
+++ b/tests/extend.spec.ts
@@ -1,0 +1,52 @@
+import playwright, { expect, test as base } from '@playwright/test'
+import { extend } from '../lib/extend'
+import { suite, TestArgs } from '../lib'
+
+playwright.describe('extend', () => {
+  type UserFixture = {
+    user: {
+      firstName: string
+      lastName: string
+    }
+  }
+
+  const withUser = base.extend<UserFixture>({
+    // eslint-disable-next-line no-empty-pattern
+    user: async ({}, use) => {
+      await use({
+        firstName: 'John',
+        lastName: 'Doe'
+      })
+    }
+  })
+
+  const { test, beforeEach, beforeAll, afterEach, afterAll } = extend<UserFixture>(withUser)
+
+  @suite()
+  class ExtendUtilSuite {
+    @beforeAll()
+    'should custom fixture be available in before all'({ user }: TestArgs<UserFixture>) {
+      expect(user).toBeDefined()
+    }
+
+    @beforeEach()
+    'should custom fixture be available in before each'({ user }: TestArgs<UserFixture>) {
+      expect(user).toBeDefined()
+    }
+
+    @afterAll()
+    'should custom fixture be available in after all'({ user }: TestArgs<UserFixture>) {
+      expect(user).toBeDefined()
+    }
+
+    @afterEach()
+    'should custom fixture be available in after each'({ user }: TestArgs<UserFixture>) {
+      expect(user).toBeDefined()
+    }
+
+    @test()
+    'should custom fixture be available in test'({ user }: TestArgs<UserFixture>) {
+      expect(user).toBeDefined()
+    }
+  }
+})


### PR DESCRIPTION
### Description
Add support for custom playwright fixtures in `beforeAll`, `beforeEach`, `test`, `afterAll` and `afterEach` decorators, by introducing `extend` method.

The `extend<T>(customFixture)` method generates decorators with access to custom fixture.

```TypeScript
import { test as base } from 'playwright';
import { suite, test, extend } from 'playwright-decorators';

// #1 Create fixture type
type UserFixture = {
    user: {
      firstName: string;
      lastName: string;
    }
}

// #2 Create user fixture
const withUser = base.extend<UserFixture>({
    user: async ({}, use) => {
        await use({
            firstName: 'John',
            lastName: 'Doe'
        })
    }
})

// #3 Generate afterAll, afterEach, test, beforeAll, beforeEach decorators with access to the user fixture
const {
    afterAll,
    afterEach,
    test,
    beforeAll,
    beforeEach,
} = extend<UserFixture>(withUser);

// #4 Use decorators
@suite()
class MyTestSuite {
    @beforeAll()
    async beforeAll({ user }: TestArgs<UserFixture>) { // have access to user fixture
        // ...
    }

    @test()
    async test({ user }: TestArgs<UserFixture>) { // have access to user fixture
        // ...
    }
}
```


